### PR TITLE
DrawMultiLinedText: add an option to provide an image as background

### DIFF
--- a/barraider-sdtools/Tools/GraphicsTools.cs
+++ b/barraider-sdtools/Tools/GraphicsTools.cs
@@ -162,6 +162,7 @@ namespace BarRaider.SdTools
         /// <summary>
         /// Generates one (or more) images where each one has a few letters drawn on them based on the parameters. You can set number of letters and number of lines per key. 
         /// Use expandToNextImage to decide if you want only one Image returned or multiple if text is too long for one key
+        /// Will generate a plain background of the provided color.
         /// </summary>
         /// <param name="text"></param>
         /// <param name="currentTextPosition"></param>
@@ -172,8 +173,55 @@ namespace BarRaider.SdTools
         /// <param name="textColor"></param>
         /// <param name="expandToNextImage"></param>
         /// <param name="keyDrawStartingPosition"></param>
-        /// <returns></returns>
-        public static Image[] DrawMultiLinedText(string text, int currentTextPosition, int lettersPerLine, int numberOfLines, Font font, Color backgroundColor, Color textColor, bool expandToNextImage, PointF keyDrawStartingPosition)
+        /// <returns>A list of images generated</returns>
+        public static Image[] DrawMultiLinedText(string text, int currentTextPosition, int lettersPerLine,
+            int numberOfLines, Font font, Color backgroundColor, Color textColor, bool expandToNextImage,
+            PointF keyDrawStartingPosition)
+        {
+            return DrawMultiLinedTextCommon(text, currentTextPosition, lettersPerLine, numberOfLines, font, backgroundColor, textColor, expandToNextImage, keyDrawStartingPosition);
+        }
+
+        /// <summary>
+        /// Generates one (or more) images where each one has a few letters drawn on them based on the parameters. You can set number of letters and number of lines per key.
+        /// Use expandToNextImage to decide if you want only one Image returned or multiple if text is too long for one key
+        /// Will use the provided background image to generate the text on top of.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="currentTextPosition"></param>
+        /// <param name="lettersPerLine"></param>
+        /// <param name="numberOfLines"></param>
+        /// <param name="font"></param>
+        /// <param name="backgroundPath"></param>
+        /// <param name="textColor"></param>
+        /// <param name="expandToNextImage"></param>
+        /// <param name="keyDrawStartingPosition"></param>
+        /// <returns>A list of images generated.</returns>
+        public static Image[] DrawMultiLinedTextWithBackground(string text, int currentTextPosition, int lettersPerLine,
+            int numberOfLines, Font font, String backgroundPath, Color textColor, bool expandToNextImage,
+            PointF keyDrawStartingPosition)
+        {
+            Image myBackground = Image.FromFile(backgroundPath);
+            return DrawMultiLinedTextCommon(text, currentTextPosition, lettersPerLine, numberOfLines, font, Color.Transparent, textColor, expandToNextImage, keyDrawStartingPosition, myBackground);
+        }
+
+        /// <summary>
+        /// Centralize the code to generate images with text wrapped:
+        /// Generates one (or more) images where each one has a few letters drawn on them based on the parameters. You can set number of letters and number of lines per key.
+        /// Use expandToNextImage to decide if you want only one Image returned or multiple if text is too long for one key
+        /// Use the background image or generate a plain background of the provided color.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="currentTextPosition"></param>
+        /// <param name="lettersPerLine"></param>
+        /// <param name="numberOfLines"></param>
+        /// <param name="font"></param>
+        /// <param name="backgroundColor"></param>
+        /// <param name="textColor"></param>
+        /// <param name="expandToNextImage"></param>
+        /// <param name="keyDrawStartingPosition"></param>
+        /// <param name="background"></param>
+        /// <returns>A list of images generated.</returns>
+        private static Image[] DrawMultiLinedTextCommon(string text, int currentTextPosition, int lettersPerLine, int numberOfLines, Font font, Color backgroundColor, Color textColor, bool expandToNextImage, PointF keyDrawStartingPosition, Image background = null)
         {
             float currentWidth = keyDrawStartingPosition.X;
             float currentHeight = keyDrawStartingPosition.Y;
@@ -182,9 +230,17 @@ namespace BarRaider.SdTools
             Bitmap img = Tools.GenerateGenericKeyImage(out Graphics graphics);
             images.Add(img);
 
-            // Draw Background
-            var bgBrush = new SolidBrush(backgroundColor);
-            graphics.FillRectangle(bgBrush, 0, 0, img.Width, img.Height);
+            if (background != null)
+            {
+                // Use the provided background
+                graphics.DrawImage(background, 0, 0, img.Width, img.Height);
+            }
+            else
+            {
+                // Draw Background
+                var bgBrush = new SolidBrush(backgroundColor);
+                graphics.FillRectangle(bgBrush, 0, 0, img.Width, img.Height);
+            }
 
             float lineHeight = img.Height / numberOfLines;
             if (numberOfLines == 1)
@@ -203,7 +259,7 @@ namespace BarRaider.SdTools
                     {
                         if (expandToNextImage)
                         {
-                            images.AddRange(DrawMultiLinedText(text, letter, lettersPerLine, numberOfLines, font, backgroundColor, textColor, expandToNextImage, keyDrawStartingPosition));
+                            images.AddRange(DrawMultiLinedTextCommon(text, letter, lettersPerLine, numberOfLines, font, backgroundColor, textColor, expandToNextImage, keyDrawStartingPosition, background));
                         }
                         break;
                     }


### PR DESCRIPTION
This feature PR offers a small extension to the very useful DrawMultiLinedText by offering an alternative method to provide a background image (instead of the plain background offered by default).

The code is kept central and the change is just at the public methods level to introduce the new call with an image.