### PR TITLE
Downgrade System.Drawing.Common to 8.0.16

### DIFF
--- a/barraider-sdtools/barraider-sdtools.csproj
+++ b/barraider-sdtools/barraider-sdtools.csproj
@@ -49,7 +49,7 @@ Feel free to contact me for more information: https://barraider.com</Description
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.3.4" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.16" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />


### PR DESCRIPTION
Referencing a 9.x package while trageting .NET 8 will cause compatibility issues with applications trying to target .NET 8 as well.

When using streamdeck-tools in my own .NET 8 tool, I ran into compatibility issue with implicit dependencies like System.Collections.Immutable

It's recommended when targeting .NET 8 to stick to the 8.x System/Microsoft dependencies.

```
0>Microsoft.Common.CurrentVersion.targets(2434,5): Warning MSB3277 : Found conflicts between different versions of "System.Collections.Immutable" that could not be resolved.
There was a conflict between "System.Collections.Immutable, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "System.Collections.Immutable, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
    "System.Collections.Immutable, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.Collections.Immutable, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not.
    References which depend on "System.Collections.Immutable, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref\net8.0\System.Collections.Immutable.dll].
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref\net8.0\System.Collections.Immutable.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref\net8.0\System.Collections.Immutable.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref/net8.0/System.Collections.Immutable.dll
    References which depend on or have been unified to "System.Collections.Immutable, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [].
        C:\Users\user\.nuget\packages\system.drawing.common\9.0.0\lib\net8.0\System.Private.Windows.Core.dll
          Project file item includes which caused reference "C:\Users\user\.nuget\packages\system.drawing.common\9.0.0\lib\net8.0\System.Private.Windows.Core.dll".
            C:\Users\user\.nuget\packages\system.drawing.common\9.0.0\lib\net8.0\System.Private.Windows.Core.dll
            C:\Users\user\.nuget\packages\system.drawing.common\9.0.0\lib\net8.0\System.Drawing.Common.dll
            C:\Users\user\.nuget\packages\streamdeck-client-csharp\4.3.0\lib\netstandard2.0\streamdeck-client-csharp.dll
            C:\Users\user\.nuget\packages\streamdeck-tools\6.3.1\lib\net8.0\StreamDeckTools.dll
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref/net8.0/System.Drawing.dll
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref\net8.0\System.Reflection.Metadata.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref\net8.0\System.Reflection.Metadata.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref/net8.0/System.Reflection.Metadata.dll
0>Microsoft.Common.CurrentVersion.targets(2434,5): Warning MSB3277 : Found conflicts between different versions of "System.Reflection.Metadata" that could not be resolved.
There was a conflict between "System.Reflection.Metadata, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" and "System.Reflection.Metadata, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a".
    "System.Reflection.Metadata, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was chosen because it was primary and "System.Reflection.Metadata, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" was not.
    References which depend on "System.Reflection.Metadata, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref\net8.0\System.Reflection.Metadata.dll].
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref\net8.0\System.Reflection.Metadata.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref\net8.0\System.Reflection.Metadata.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref/net8.0/System.Reflection.Metadata.dll
    References which depend on or have been unified to "System.Reflection.Metadata, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" [].
        C:\Users\user\.nuget\packages\system.drawing.common\9.0.0\lib\net8.0\System.Private.Windows.Core.dll
          Project file item includes which caused reference "C:\Users\user\.nuget\packages\system.drawing.common\9.0.0\lib\net8.0\System.Private.Windows.Core.dll".
            C:\Users\user\.nuget\packages\system.drawing.common\9.0.0\lib\net8.0\System.Private.Windows.Core.dll
            C:\Users\user\.nuget\packages\system.drawing.common\9.0.0\lib\net8.0\System.Drawing.Common.dll
            C:\Users\user\.nuget\packages\streamdeck-client-csharp\4.3.0\lib\netstandard2.0\streamdeck-client-csharp.dll
            C:\Users\user\.nuget\packages\streamdeck-tools\6.3.1\lib\net8.0\StreamDeckTools.dll
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\8.0.16\ref/net8.0/System.Drawing.dll
```