### PR TITLE
fix: preserve StreamDeckOptions metadata for trimmed .NET 8 apps

### DIFF
--- a/barraider-sdtools/Backend/SDWrapper.cs
+++ b/barraider-sdtools/Backend/SDWrapper.cs
@@ -2,6 +2,9 @@
 using BarRaider.SdTools.Payloads;
 using CommandLine;
 using System;
+#if NET8_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace BarRaider.SdTools
 {
@@ -45,6 +48,9 @@ namespace BarRaider.SdTools
         /// <param name="args"></param>
         /// <param name="supportedActionIds"></param>
         /// /// <param name="updateHandler"></param>
+#if NET8_0_OR_GREATER
+        [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties, typeof(StreamDeckOptions))]
+#endif
         private static void Run(string[] args, PluginActionId[] supportedActionIds, IUpdateHandler updateHandler)
         {
             Logger.Instance.LogMessage(TracingLevel.INFO, $"Plugin [{Tools.GetExeName()}] Loading - {supportedActionIds.Length} Actions Found");


### PR DESCRIPTION
## Summary
- add a `DynamicDependency` annotation on `SDWrapper.Run(...)` for `StreamDeckOptions`
- preserve public constructors and properties used by `CommandLineParser` reflection in trimmed/self-contained .NET 8 publishes
- scope the annotation to `NET8_0_OR_GREATER` to avoid impacting netstandard targets

## Testing
- `dotnet` SDK is not available in this runtime (`dotnet: command not found`), so build/test could not be executed locally
- ran `git diff --check` to confirm no whitespace/patch formatting issues
- verification intent: a trimmed self-contained plugin publish should no longer throw `Type ... StreamDeckOptions appears to be immutable, but no constructor found`

## Related
Fixes #83
